### PR TITLE
Warn when visualization cutoff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/egraphs-good/egglog-demo"
 crate-type = ["cdylib"]
 
 [dependencies]
-egglog = { path = "egglog-upstream" }
-egglog-experimental = { path = "experimental-upstream" }
+egglog = { path = "egglog-upstream", default-features = false, features = ["serde", "graphviz"] }
+egglog-experimental = { path = "experimental-upstream",  default-features = false }
 log = "0.4.19"
 wasm-logger = "0.2"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ web-sys = { version = "0.3.64", features = [
   "Worker",
   "DedicatedWorkerGlobalScope",
 ] }
+
+[patch.'https://github.com/egraphs-good/egglog']
+egglog = { path = "egglog-upstream" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "egglog-demo"
 version = "0.5.0"
 description = "Web demo for egglog, an e-graph library for equality saturation and term rewriting."

--- a/Makefile
+++ b/Makefile
@@ -5,20 +5,25 @@
 
 all: build dist
 
-build: upstream
+build: egglog-upstream experimental-upstream tutorial-upstream
 	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack build --target no-modules --no-typescript
 
-dist: static/examples.json
+dist: static/examples.json static/ pkg/
 	mkdir -p  $@
 	cp -rf static/*  $@
 	cp -rf pkg/*  $@
 
-upstream:
-	git clone https://github.com/egraphs-good/egglog.git              --depth 1 egglog-upstream
-	git clone https://github.com/egraphs-good/egglog-experimental.git --depth 1 experimental-upstream
-	git clone https://github.com/egraphs-good/egglog-tutorial.git     --depth 1 tutorial-upstream
 
-static/examples.json: upstream
+egglog-upstream:
+	git clone https://github.com/egraphs-good/egglog.git --depth 1 $@
+
+experimental-upstream:
+	git clone https://github.com/egraphs-good/egglog-experimental.git --depth 1 $@
+
+tutorial-upstream:
+	git clone https://github.com/egraphs-good/egglog-tutorial.git --depth 1 $@
+
+static/examples.json: egglog-upstream experimental-upstream tutorial-upstream
 	./examples.py \
 		$(shell find       egglog-upstream/tests/web-demo -type f -name '*.egg') \
 		$(shell find experimental-upstream/tests/web-demo -type f -name '*.egg') \
@@ -26,4 +31,4 @@ static/examples.json: upstream
 		> static/examples.json
 
 clean:
-	rm -rf pkg dist egglog-upstream experimental-upstream
+	rm -rf pkg dist egglog-upstream experimental-upstream tutorial-upstream

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.87.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-#![allow(clippy::unused_unit)] // weird clippy bug with wasm-bindgen
-use egglog_experimental::SerializeConfig;
+use egglog::SerializeConfig;
 use log::{Level, Log, Metadata, Record};
 use wasm_bindgen::prelude::*;
 use web_sys::console;

--- a/static/index.html
+++ b/static/index.html
@@ -138,6 +138,9 @@
             output.scrollTop = output.scrollHeight;
             fulllog = message.data.log;
             window.previousEGraphs.push(message.data.json);
+            if (message.data.omitted) {
+                alert(`Max nodes exceeded for visualizaton. ${message.data.omitted}`);
+            }
             refreshLog();
             window.fillGraph();
         }

--- a/static/worker.js
+++ b/static/worker.js
@@ -13,7 +13,7 @@ async function work() {
             console.log("Got result from worker", result);
             // Can't send the result directly, since it contains a reference to the
             // wasm memory. Instead, we send the dot and text separately.
-            self.postMessage({ dot: result.dot, text: result.text, log: logbuffer, json: result.json });
+            self.postMessage({ dot: result.dot, text: result.text, log: logbuffer, json: result.json, omitted: result.omitted });
         } catch (error) {
             console.log(error);
             self.postMessage({ dot: "", text: "Something panicked! Check the console logs...", log: logbuffer, json: "{}" });


### PR DESCRIPTION
Fixes #8 and #10 to warn when the visualization is cut off.

For example, if you change the schedule demo to run 50 times, it will now pop up with this error:


<img width="1792" height="719" alt="Screenshot 2025-09-02 at 12 37 25 AM" src="https://github.com/user-attachments/assets/1e24bac5-4198-40ff-9eb6-7bd096ef56be" />


Eventually it might be nicer to add an overlay to the graph to show the error, but for now this seemed easiest. 

This PR also makes a few QoL improvements around the Makefile