### PR TITLE
Fix Builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,15 @@ repository = "https://github.com/egraphs-good/egglog-demo"
 crate-type = ["cdylib"]
 
 [dependencies]
-egglog = { path = "egglog-upstream", default-features = false, features = ["serde", "graphviz"] }
-egglog-experimental = { path = "experimental-upstream",  default-features = false }
 log = "0.4.19"
+egglog = { git = "https://github.com/saulshanabrook/egg-smol.git", branch = "update-deps", default-features = false, features = ["serde", "graphviz"]  }
+egglog-experimental = { git = "https://github.com/egraphs-good/egglog-experimental", branch = "update-deps", default-features = false }
 wasm-logger = "0.2"
 serde_json = "1.0"
 console_error_panic_hook = "0.1.7"
 js-sys = "0.3"
 wasm-bindgen = "0.2"
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 web-sys = { version = "0.3.64", features = [
   # "Blob",
   # "BlobPropertyBag",
@@ -34,5 +34,12 @@ web-sys = { version = "0.3.64", features = [
   "DedicatedWorkerGlobalScope",
 ] }
 
+# Use patched version of egglog in experimental
 [patch.'https://github.com/egraphs-good/egglog']
-egglog = { path = "egglog-upstream" }
+egglog = { git = "https://github.com/saulshanabrook/egg-smol.git", branch = "update-deps" }
+egglog-ast = { git = "https://github.com/saulshanabrook/egg-smol.git", branch = "update-deps" }
+
+# Use patched version of egraph-serialize for newer random version
+[patch.crates-io]
+egraph-serialize = { git = "https://github.com/saulshanabrook/egraph-serialize.git", branch = "update-deps" }
+graphviz-rust = { git = "https://github.com/saulshanabrook/graphviz-rust.git", branch = "master" }

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,9 @@
 
 .PHONY: all build clean
 
-
 all: build dist
 
-build: egglog-upstream experimental-upstream tutorial-upstream
+build: tutorial-upstream
 	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack build --target no-modules --no-typescript
 
 dist: static/examples.json static/ pkg/
@@ -13,22 +12,11 @@ dist: static/examples.json static/ pkg/
 	cp -rf static/*  $@
 	cp -rf pkg/*  $@
 
-
-egglog-upstream:
-	git clone https://github.com/egraphs-good/egglog.git --depth 1 $@
-
-experimental-upstream:
-	git clone https://github.com/egraphs-good/egglog-experimental.git --depth 1 $@
-
 tutorial-upstream:
 	git clone https://github.com/egraphs-good/egglog-tutorial.git --depth 1 $@
 
-static/examples.json: egglog-upstream experimental-upstream tutorial-upstream
-	./examples.py \
-		$(shell find       egglog-upstream/tests/web-demo -type f -name '*.egg') \
-		$(shell find experimental-upstream/tests/web-demo -type f -name '*.egg') \
-		$(shell find     tutorial-upstream                -type f -name '*.egg') \
-		> static/examples.json
+static/examples.json: tutorial-upstream
+	./examples.py  > $@
 
 clean:
-	rm -rf pkg dist egglog-upstream experimental-upstream tutorial-upstream
+	rm -rf pkg dist tutorial-upstream static/examples.json

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This repository contains the web demo for [egglog](https://github.com/egraphs-go
 3. **Build the WebAssembly package and copy static files:**
 
    ```fish
-   make all
+   make
    ```
 
    This will generate the necessary `.wasm` and JS files in the `pkg/` directory and copy everything to `dist/`.
@@ -54,11 +54,11 @@ This repository contains the web demo for [egglog](https://github.com/egraphs-go
 - `src/` — Rust source code for the WebAssembly module
 - `static/` — Static files for the web demo (HTML, JS, CSS)
 - `examples.py` — Script to bundle example `.egg` files as JSON for the demo
-- `egglog-upstream/` — Local clone of the upstream [egglog](https://github.com/egraphs-good/egglog) repo (ignored by git)
+- `tutorial-upstream/` — Local clone of the upstream [egglog tutorial](https://github.com/egraphs-good/egglog-tutorial) repo (ignored by git)
 
 ## Examples
 
-The web demo loads its example programs from the `tests` directories of the upstream [egglog](https://github.com/egraphs-good/egglog). These are automatically downloaded and bundled into a JSON file (`static/examples.json`) by running:
+The web demo loads its example programs from the `tests` directories of the upstream [egglog](https://github.com/egraphs-good/egglog), [egglog-experimental](https://github.com/egraphs-good/egglog-experimental), and [egglog tutorial](https://github.com/egraphs-good/egglog-tutorial) projects. These are automatically downloaded and bundled into a JSON file (`static/examples.json`) by running:
 
 ```fish
 make static/examples.json

--- a/examples.py
+++ b/examples.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 
 import json
-import os
 import sys
 from pathlib import Path
+import subprocess
 
-if len(sys.argv) <= 1:
-    print("ERROR: give some files as input")
-    sys.exit(1)
+metadata_process = subprocess.run(
+    ["cargo", "metadata", "--format-version", "1", "-q"],  # noqa: S607
+    capture_output=True,
+    check=True,
+)
 
-files = sorted(sys.argv[1:], key = os.path.basename)
-
-result = {}
-for filename in files:
-    with open(filename) as f:
-        name = Path(filename).stem
-        result[name] = f.read()
-
+root_paths = [
+    Path(package["manifest_path"]).parent / "tests" / "web-demo"
+    for package in json.loads(metadata_process.stdout)["packages"]
+    if package["name"] in ["egglog", "egglog-experimental"]
+]
+root_paths.append(Path(__file__).parent / "tutorial-upstream")
+egg_paths = [egg for path in root_paths for egg in path.glob("**/*.egg")]
+result = {path.stem: path.read_text() for path in egg_paths}
 json.dump(result, sys.stdout, indent=2)


### PR DESCRIPTION
This PR fixes CI builds. It does so by updating recursively versions of `getrandom` so that `0.3` can be universally installed, which has a new feature flag for enabling JS builds.

This depends on the following in flight PRs, which for now have been pulled in directly to allow building before they are merged:

- https://github.com/egraphs-good/egglog-experimental/pull/27
- https://github.com/egraphs-good/egglog/pull/690
- https://github.com/egraphs-good/egraph-serialize/pull/22
- https://github.com/besok/graphviz-rust/pull/47


It also updates other dependencies while we are at it. 

It changes the build script as well to not need explicit cloning of these repositories, but instead just depending on them in cargo with git, and looking at the cloned cargo folders to find the example files. It moves all this logic into the examples python file, from the makefile.

This makes it a little simpler to get started and manage the dependencies simply in the cargo instead of having to worry about git clones.